### PR TITLE
[WIDGPT-57] Updated support for handling window-state specific JSPs.  Up...

### DIFF
--- a/src/main/java/org/jasig/portlet/widget/service/IWindowStateAwareJspMapper.java
+++ b/src/main/java/org/jasig/portlet/widget/service/IWindowStateAwareJspMapper.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.widget.service;
+
+import javax.portlet.WindowState;
+import java.util.Locale;
+
+/**
+ * Lookup what JSP to use based on a JSP basename and a window state.
+ *
+ * @author Josh Helmer, jhelmer.unicon.net
+ * @since 1.4.2
+ */
+public interface IWindowStateAwareJspMapper {
+    /**
+     * Given a base name, a window state and a locale, lookup the name of the JSP
+     * to render.  Default impl is to look for files like <baseName>.<windowState>.jsp
+     * If the file exists, use that.  If it does not exist, return baseName
+     *
+     * @param baseName the configured JSP name
+     * @param windowState the window state for the current request
+     * @param locale the locale for the current request.
+     *
+     * @return The jsp name to use based on basename and windowState
+     */
+    String getJspName(String baseName, WindowState windowState, Locale locale);
+}

--- a/src/main/java/org/jasig/portlet/widget/service/IWindowStateAwareJspNameMapper.java
+++ b/src/main/java/org/jasig/portlet/widget/service/IWindowStateAwareJspNameMapper.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.widget.service;
+
+import javax.portlet.WindowState;
+
+/**
+ * @author Josh Helmer, jhelmer.unicon.net
+ * @since 1.4.2
+ */
+public interface IWindowStateAwareJspNameMapper {
+    /**
+     * Mapper to define the format for state-specific JSP files.
+     *
+     * @param baseName the base JSP name
+     * @param state the window state
+     * @return the mapped name.
+     */
+    String getName(String baseName, WindowState state);
+}

--- a/src/main/java/org/jasig/portlet/widget/service/WindowStateAwareJspMapper.java
+++ b/src/main/java/org/jasig/portlet/widget/service/WindowStateAwareJspMapper.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.widget.service;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.Element;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Required;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.ServletContextAware;
+import org.springframework.web.servlet.View;
+import org.springframework.web.servlet.view.AbstractUrlBasedView;
+import org.springframework.web.servlet.view.UrlBasedViewResolver;
+
+import javax.annotation.Resource;
+import javax.portlet.WindowState;
+import javax.servlet.ServletContext;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Implementation that maps the JSP to a name using a IWindowStateAwareJspNameMapper and
+ * then checks if the mapped JSP exists.  If so, use it, otherwise use the default JSP
+ *
+ * @author Josh Helmer, jhelmer.unicon.net
+ * @since 1.4.2
+ */
+@Service
+public class WindowStateAwareJspMapper implements IWindowStateAwareJspMapper, ServletContextAware {
+    private ServletContext servletContext;
+    private IWindowStateAwareJspNameMapper nameMapper;
+    private UrlBasedViewResolver jspResolver;
+    // should be a very small # of these and there is no real reason for
+    // cache expiration.  So, for now just use a map.
+    private Map<String, Boolean> stateAwareJspExists = new HashMap<String, Boolean>();
+
+
+    @Autowired
+    public void setNameMapper(final IWindowStateAwareJspNameMapper nameMapper) {
+        this.nameMapper = nameMapper;
+    }
+
+
+    @Autowired
+    public void setJspResolver(final UrlBasedViewResolver jspResolver) {
+        this.jspResolver = jspResolver;
+    }
+
+
+    @Override
+    public void setServletContext(final ServletContext servletContext) {
+        this.servletContext = servletContext;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getJspName(String baseName, WindowState windowState, Locale locale) {
+        String stateName = nameMapper.getName(baseName, windowState);
+        if (stateSpecificJspExists(stateName, locale)) {
+            return stateName;
+        }
+
+        return baseName;
+    }
+
+
+    /**
+     * Given a window-state-aware JSP name, check if the JSP exists.
+     *
+     * @param stateJsp the JSP name
+     * @param locale the locale of the request
+     * @return true if the JSP exists, else false
+     */
+    private boolean stateSpecificJspExists(String stateJsp, Locale locale) {
+        // check the "cache"...
+        if (stateAwareJspExists.containsKey(stateJsp)) {
+            return stateAwareJspExists.get(stateJsp);
+        }
+
+        try {
+            View view = jspResolver.resolveViewName(stateJsp, locale);
+            if (!(view instanceof AbstractUrlBasedView)) {
+                return false;
+            }
+
+            String url = ((AbstractUrlBasedView)view).getUrl();
+            String path = servletContext.getRealPath(url);
+            File f = new File(path);
+            boolean exists = f.exists();
+
+            // cache the results...
+            stateAwareJspExists.put(stateJsp, exists);
+
+            return exists;
+
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/jasig/portlet/widget/service/WindowStateAwareJspNameMapper.java
+++ b/src/main/java/org/jasig/portlet/widget/service/WindowStateAwareJspNameMapper.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.widget.service;
+
+import org.springframework.stereotype.Service;
+
+import javax.portlet.WindowState;
+
+/**
+ * Default Mapper that builds the JSP name for state-specific JSPs.
+ * This impl will return baseName in the case of WindowState being null
+ * else, it will return <baseName>.<windowState.toLowerCase()>
+ *
+ * @author Josh Helmer, jhelmer.unicon.net
+ * @since 1.4.2
+ */
+@Service
+public class WindowStateAwareJspNameMapper implements IWindowStateAwareJspNameMapper {
+    @Override
+    public String getName(String baseName, WindowState state) {
+        if (state == null) {
+            return baseName;
+        }
+
+        return baseName + "." + state.toString().toLowerCase();
+    }
+}

--- a/src/test/java/org/jasig/portlet/widget/service/WindowStateAwareJspMapperTest.java
+++ b/src/test/java/org/jasig/portlet/widget/service/WindowStateAwareJspMapperTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.widget.service;
+
+import org.jasig.portlet.widget.mvc.SimpleJspPortletController;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.ui.Model;
+import org.springframework.web.servlet.View;
+import org.springframework.web.servlet.view.JstlView;
+import org.springframework.web.servlet.view.UrlBasedViewResolver;
+
+import javax.portlet.PortletPreferences;
+import javax.portlet.RenderRequest;
+import javax.portlet.WindowState;
+import javax.servlet.ServletContext;
+import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * @author Josh Helmer, jhelmer.unicon.net
+ */
+public class WindowStateAwareJspMapperTest {
+    private static String BASE_JSP_NAME = "baseName";
+
+    @Mock
+    private ServletContext servletContext;
+    private WindowStateAwareJspMapper windowStateAwareJspMapper;
+    private Locale locale = Locale.getDefault();
+
+    @Before
+    public void setup() throws Exception {
+        initMocks(this);
+
+        UrlBasedViewResolver viewResolver = spy(new UrlBasedViewResolver());
+        Answer<View> answer = new Answer<View>() {
+            @Override
+            public View answer(InvocationOnMock invocationOnMock) throws Throwable {
+                String jspName = (String)invocationOnMock.getArguments()[0];
+                return new JstlView("/WEB-INF/jsp/" + jspName + ".jsp");
+            }
+        };
+        doAnswer(answer).when(viewResolver).resolveViewName(anyString(), any(Locale.class));
+
+        windowStateAwareJspMapper = new WindowStateAwareJspMapper();
+        windowStateAwareJspMapper.setNameMapper(new WindowStateAwareJspNameMapper());
+        windowStateAwareJspMapper.setJspResolver(viewResolver);
+        windowStateAwareJspMapper.setServletContext(servletContext);
+    }
+
+
+    @Test
+    public void testNoWindowStateJSP() {
+        // given window-state specific JSP does not exist
+        when(servletContext.getRealPath(anyString())).thenReturn("INVALID_FILENAME");
+
+        String jsp = windowStateAwareJspMapper.getJspName(BASE_JSP_NAME, WindowState.MAXIMIZED, locale);
+
+        assertThat(jsp, is(BASE_JSP_NAME));
+    }
+
+
+    @Test
+    public void testWindowStateJSPExists() throws IOException {
+        String maxJspName = BASE_JSP_NAME + ".maximized";
+
+        // given window-state specific JSP does exist
+        File testFile = File.createTempFile("windowStateAwareJspMapperTest", "txt");
+        when(servletContext.getRealPath(eq(fullPath(maxJspName))))
+                .thenReturn(testFile.getAbsolutePath());
+
+        // when I resolve the view
+        String jsp = windowStateAwareJspMapper.getJspName(BASE_JSP_NAME, WindowState.MAXIMIZED, locale);
+
+        // then I should get the state specific JSP
+        assertThat(jsp, is(maxJspName));
+    }
+
+
+    @Test
+    public void testWindowStateJSPCaching() throws IOException {
+        // given I setup a window-state-aware mapper
+        when(servletContext.getRealPath(anyString())).thenReturn("INVALID_FILENAME");
+
+        // when I make repeated requests for a JSP/state combination
+        windowStateAwareJspMapper.getJspName(BASE_JSP_NAME, WindowState.MAXIMIZED, locale);
+        windowStateAwareJspMapper.getJspName(BASE_JSP_NAME, WindowState.NORMAL, locale);
+        windowStateAwareJspMapper.getJspName(BASE_JSP_NAME, WindowState.MINIMIZED, locale);
+
+        windowStateAwareJspMapper.getJspName(BASE_JSP_NAME, WindowState.MAXIMIZED, locale);
+        windowStateAwareJspMapper.getJspName(BASE_JSP_NAME, WindowState.NORMAL, locale);
+        windowStateAwareJspMapper.getJspName(BASE_JSP_NAME, WindowState.NORMAL, locale);
+        windowStateAwareJspMapper.getJspName(BASE_JSP_NAME, WindowState.MINIMIZED, locale);
+        windowStateAwareJspMapper.getJspName(BASE_JSP_NAME, WindowState.MINIMIZED, locale);
+        windowStateAwareJspMapper.getJspName(BASE_JSP_NAME, WindowState.MINIMIZED, locale);
+
+        // then I see that file check is only performed once per JSP/state combination
+        verify(servletContext, times(1)).getRealPath(fullPath(BASE_JSP_NAME + ".maximized"));
+        verify(servletContext, times(1)).getRealPath(fullPath(BASE_JSP_NAME + ".normal"));
+        verify(servletContext, times(1)).getRealPath(fullPath(BASE_JSP_NAME + ".minimized"));
+    }
+
+
+    private String fullPath(String jspPart) {
+        return "/WEB-INF/jsp/" + jspPart + ".jsp";
+    }
+}

--- a/src/test/java/org/jasig/portlet/widget/service/WindowStateAwareJspNameMapperTest.java
+++ b/src/test/java/org/jasig/portlet/widget/service/WindowStateAwareJspNameMapperTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.widget.service;
+
+import org.junit.Test;
+
+import javax.portlet.WindowState;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Josh Helmer, jhelmer.unicon.net
+ */
+public class WindowStateAwareJspNameMapperTest {
+    @Test
+    public void testNullState() {
+        WindowStateAwareJspNameMapper mapper = new WindowStateAwareJspNameMapper();
+        String name = mapper.getName("test", null);
+
+        assertThat(name, is("test"));
+    }
+
+
+    @Test
+    public void testWithWindowState() {
+        WindowStateAwareJspNameMapper mapper = new WindowStateAwareJspNameMapper();
+        String name = mapper.getName("test", WindowState.MAXIMIZED);
+
+        assertThat(name, is("test.maximized"));
+    }
+}


### PR DESCRIPTION
Update to my previous PR based on post-merge pull request comments.    Previously, I had added support for a new portlet preference for configuring the JSP page to use based on window state.   This version relys on convention and removes the portlet preference.

In this case, the portlet will first look for a JSP like [basename].[window-state].jsp where basename is the configured JSP name and window-state is the current window state (lowercase).   If that file exists, it will be used.   If it does not exist, the portlet will fall back to just using the configured JSP.

@jameswennmacher let me know if this is not more what you had in mind.
