### PR TITLE
chore: migrate jasig-parent → uportal-portlet-parent:46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <parent>
-        <groupId>org.jasig.parent</groupId>
-        <artifactId>jasig-parent</artifactId>
-        <version>41</version>
+        <groupId>org.jasig.portlet</groupId>
+        <artifactId>uportal-portlet-parent</artifactId>
+        <version>46</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -132,11 +132,6 @@
                 <version>${icu4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>3.2.2</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>2.16.1</version>
@@ -160,11 +155,6 @@
                 <groupId>javax.servlet</groupId>
                 <artifactId>jstl</artifactId>
                 <version>1.1.2</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>2.5</version>
             </dependency>
             <dependency>
                 <groupId>jaxen</groupId>
@@ -192,6 +182,11 @@
                     <exclusion>
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <!-- Pulls servlet-api 2.4 (banned by parent). -->
+                    <exclusion>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>servlet-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -473,10 +468,6 @@
             <artifactId>ehcache-spring-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
@@ -607,9 +598,10 @@
             <artifactId>portlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- servlet-api provided at runtime by Tomcat; version managed by uportal-portlet-parent. -->
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Consume the newly-released `uportal-portlet-parent:44` instead of the old `org.jasig.parent:jasig-parent:41`. One-line `<parent>` bump.

### What v44 brings

- Central Publisher Portal `<distributionManagement>` (replaces the dead `oss.sonatype.org` URLs that were sunset June 2025)
- `<developers>` block required for Central Portal validation
- Java 11 compiler default
- Drops the unmaintained `org.sonatype.oss:oss-parent:9` inheritance

Part of the ecosystem-wide sweep. Validated with `mvn help:effective-pom -N`.

Parent release: uPortal-Project/uportal-portlet-parent#7