### PR TITLE
fix: downgrade portlet-api from 3.0.1 to 2.0 (JSR-286)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,6 @@
         <dependency>
             <groupId>javax.portlet</groupId>
             <artifactId>portlet-api</artifactId>
-            <version>3.0.1</version>
             <scope>provided</scope>
         </dependency>
         <!-- servlet-api provided at runtime by Tomcat; version managed by uportal-portlet-parent. -->


### PR DESCRIPTION
## Summary

This portlet declared `portlet-api:3.0.1` (JSR-362) in its `<dependencies>`, but uPortal runs the **JSR-286 (Portlet API 2.0)** container. A WAR compiled against 3.0.1 would have worked only *accidentally* — any code that used a JSR-362-only method would have `NoSuchMethodError`'d at runtime.

### Source scan — no JSR-362-only API usage

- No `javax.portlet.annotations.*` (new in 3.0): `@PortletApplication`, `@PortletConfiguration`, etc.
- No `PortletAsyncContext`, `HeaderFilter`, `HeaderRequest`, `HeaderResponse`
- No `MutableActionParameters`, `MutableRenderParameters`, or the 3.0 `ActionURL`/`RenderURL`/`ResourceURL` subinterfaces
- The one `createActionURL()` call returns the base `PortletURL` — JSR-286 style

### Change

Drop the explicit `<version>3.0.1</version>` so this portlet inherits `portlet-api:2.0` from `uportal-portlet-parent:48`'s dependencyManagement.

Pairs with the Renovate pin in #285 (`portlet-api < 3.0`) — together they ensure the declared and resolved versions stay aligned with the runtime container.

## Test plan
- [x] `mvn dependency:tree` resolves to `javax.portlet:portlet-api:jar:2.0:provided`
- [x] `mvn compile` passes on Java 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)