### PR TITLE
chore: tighten renovate pins

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,31 +7,47 @@
   "renovateFork": true,
   "packageRules": [
     {
-      "matchPackageNames": [
-        "javax.portlet:portlet-api"
-      ],
+      "matchPackageNames": ["javax.portlet:portlet-api"],
       "allowedVersions": "< 3.0",
       "description": "uPortal runs JSR-286 (Portlet API 2.0). Portlet API 3.x (JSR-362) is a different container contract and is not supported."
     },
     {
+      "matchPackagePrefixes": ["org.springframework:", "org.springframework.data:"],
+      "allowedVersions": "< 5.0",
+      "description": "This portlet is pinned to Spring Framework 4.3.x. Spring 5+ requires a coordinated migration; Spring 6+ additionally needs Jakarta EE + Java 17+."
+    },
+    {
       "matchPackageNames": [
-        "org.springframework:spring-framework-bom",
-        "org.springframework:spring-aop",
-        "org.springframework:spring-beans",
-        "org.springframework:spring-context",
-        "org.springframework:spring-context-support",
-        "org.springframework:spring-core",
-        "org.springframework:spring-jdbc",
-        "org.springframework:spring-orm",
-        "org.springframework:spring-test",
-        "org.springframework:spring-tx",
-        "org.springframework:spring-web",
-        "org.springframework:spring-webmvc",
-        "org.springframework:spring-webmvc-portlet",
-        "org.springframework.data:spring-data-jpa"
+        "com.sun.xml.bind:jaxb-impl",
+        "jakarta.xml.bind:jakarta.xml.bind-api",
+        "org.glassfish.jaxb:jaxb-runtime"
+      ],
+      "allowedVersions": "< 3.0",
+      "description": "The 2.x releases preserve the javax.xml.bind.* package namespace. 3+ moves to jakarta.xml.bind as part of Jakarta EE 9+, which this portlet is not migrating to yet."
+    },
+    {
+      "matchPackagePrefixes": ["org.jvnet.jaxb2_commons:"],
+      "allowedVersions": "< 1.0",
+      "description": "This portlet uses jaxb2-basics 0.6.0 (last 0.x). The 1.x release requires jaxb2-maven-plugin 1.x+ which has a substantially different plugin configuration; not doing that migration yet."
+    },
+    {
+      "matchPackageNames": ["org.codehaus.plexus:plexus-archiver"],
+      "allowedVersions": "< 4.10.0",
+      "description": "plexus-archiver 4.10+ requires a newer commons-io (BoundedInputStream.builder()) than the one bundled with maven-war-plugin 3.4.0 (pinned by uportal-portlet-parent). Revisit once the parent bumps maven-war-plugin to 3.5.x+."
+    },
+    {
+      "matchPackageNames": [
+        "org.mockito:mockito-core",
+        "org.mockito:mockito-inline",
+        "org.mockito:mockito-junit-jupiter"
       ],
       "allowedVersions": "< 5.0",
-      "description": "This portlet is pinned to Spring Framework 4.3.x. Next-major bumps require a coordinated migration."
+      "description": "Mockito 5 uses the inline MockMaker by default; its bundled byte-buddy references ClassFileVersion.JAVA_V21, missing on the byte-buddy pulled transitively via Javassist. Stay on Mockito 4.x until byte-buddy can be reconciled at the parent level."
+    },
+    {
+      "matchPackageNames": ["javax.servlet:javax.servlet-api"],
+      "allowedVersions": "< 5.0",
+      "description": "Servlet API 5+ is in the Jakarta EE namespace and incompatible with this portlet's javax.servlet imports. Runtime is Tomcat 8.5/9 (Servlet 3.1)."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add jaxb/jaxb2-basics/plexus-archiver/mockito/javax.servlet-api pins + switch Spring to matchPackagePrefixes. Blocks #131 + #63 (jaxb2-basics v0.13+/v1), #186 (mockito v5), #287 (jaxb v2.3.9 if artifact version doesn't exist), and future plexus-archiver 4.10+ / servlet-api v5+ proposals.

Same pattern we've applied across the fleet (Bookmarks #136, SimpleContent #522, Webproxy #264): consolidate hand-maintained `matchPackageNames` lists to `matchPackagePrefixes`, add jaxb (`com.sun.xml.bind:jaxb-impl`, `jakarta.xml.bind:jakarta.xml.bind-api`, `org.glassfish.jaxb:jaxb-runtime`) < 3.0 to preserve the `javax.xml.bind.*` namespace, add `plexus-archiver` < 4.10.0 because 4.10+ breaks the current maven-war-plugin 3.4.0 bundled commons-io, add `mockito-core`/`inline`/`junit-jupiter` < 5.0 due to the byte-buddy classpath clash with Hibernate/Javassist.

**Dependabot PRs** are not affected by `renovate.json` — any spring 5.2/6.x, hibernate 5.x, etc. from Dependabot need manual closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)