### PR TITLE
chore: bump parent to v49 and inherit license-plugin defaults

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>48</version>
+        <version>49</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -838,29 +838,21 @@
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <configuration>
-                        <aggregate>true</aggregate>
+                        <!--
+                          | Parent v49 provides the standard excludes
+                          | (target/**, bin/**, pom.xml.*, release.properties,
+                          | LICENSE, NOTICE, docs/**, .idea/**, overlays/**)
+                          | and mappings (tld, xjb). Local block keeps only
+                          | the JasigWidgetPortlets-specific excludes.
+                        +-->
                         <excludes>
-                            <exclude>target/**</exclude>
-                            <exclude>bin/**</exclude>
-                            <exclude>pom.xml.*</exclude>
-                            <exclude>release.properties</exclude>
-                            <exclude>LICENSE</exclude>
-                            <exclude>NOTICE</exclude>
-                            <exclude>docs/**</exclude>
                             <exclude>**/*.channel</exclude>
                             <exclude>**/*.portlet.xml</exclude>
                             <exclude>**/*.json</exclude>
                             <exclude>src/main/webapp/css/*.css</exclude> <!-- LESSCSS (unfortunately) builds to here -->
                             <exclude>src/test/resources/org/jasig/portlet/widget/service/*.html</exclude>
-                            <exclude>src/test/resources/org/jasig/portlet/widget/service/googlecalendarviewer.xml
-                            </exclude>
-                            <exclude>.idea/**</exclude>  <!-- Exclude intelliJ Idea working folders -->
-                            <exclude>overlays/**</exclude>  <!-- Exclude intelliJ Idea working folders -->
+                            <exclude>src/test/resources/org/jasig/portlet/widget/service/googlecalendarviewer.xml</exclude>
                         </excludes>
-                        <mapping>
-                            <tld>XML_STYLE</tld>
-                            <xjb>XML_STYLE</xjb>
-                        </mapping>
                     </configuration>
                 </plugin>
             <plugin>

--- a/src/main/webapp/less/app/icon.less
+++ b/src/main/webapp/less/app/icon.less
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 /**
   * Licensed to Jasig under one or more contributor license
   * agreements. See the NOTICE file distributed with this work

--- a/src/main/webapp/less/jasig-widget-portlets.less
+++ b/src/main/webapp/less/jasig-widget-portlets.less
@@ -1,22 +1,21 @@
-/**
- * Licensed to Jasig under one or more contributor license
+/*
+ * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.
- * Jasig licenses this file to you under the Apache License,
+ * Apereo licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a
- * copy of the License at:
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
-
 /**
  * NOTE: this file is located outside the less/ directory due to a limitation
  * in the LESS CSS Maven Plugin's inability to traverse relative paths.


### PR DESCRIPTION
## Summary

Bumps to parent v49 and shrinks the license-plugin block to just the JasigWidgetPortlets-specific excludes. Adds missing headers to 2 `.less` files via `license:format`.

Part of the post-v49 fleet sweep.

## Changes

`pom.xml`:
- Parent `48` → `49`.
- Drop `<aggregate>true</aggregate>` (parent default).
- Shrink `<excludes>` from 16 entries to 6 — keep only `**/*.channel`, `**/*.portlet.xml`, `**/*.json`, `src/main/webapp/css/*.css` (LESSCSS build output), and the two test-resource paths under `src/test/resources/.../widget/service/`.
- Drop redundant mappings `<tld>` and `<xjb>` — parent has both.

Source re-headering via `mvn license:format`:
- `src/main/webapp/less/app/icon.less` and `src/main/webapp/less/jasig-widget-portlets.less` re-headered Apereo SLASHSTAR (were missing entirely).


## Out of scope

`maven-compiler-plugin` still pins `source/target=1.8` — same fleet-floor question as FeedbackPortlet. Saved for a follow-up.

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green
- [x] `mvn license:check` — green
- [ ] CI on Java 11 matrix
