### PR TITLE
fix: drop dead commons-httpclient 3.1-osgi pin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,21 +196,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <!--
-             | For the present, including both old and new versions of Apache
-             | httpclient;  YouTubeService needs to be updated to use the new.
-             +-->
-            <dependency>
-                <groupId>commons-httpclient</groupId>
-                <artifactId>commons-httpclient</artifactId>
-                <version>3.1-osgi</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
@@ -530,21 +515,6 @@
                 <exclusion>
                     <groupId>commons-collections</groupId>
                     <artifactId>commons-collections</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!--
-         | For the present, including both old and new versions of Apache
-         | httpclient;  YouTubeService needs to be updated to use the new.
-         +-->
-        <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1-osgi</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Closes Dependabot CVE-2012-5783 (commons-httpclient SSL hostname verification).

JasigWidgetPortlets historically carried both `commons-httpclient:3.1-osgi` and modern `org.apache.httpcomponents:httpclient` side-by-side. A comment in the pom — *'including both old and new versions of Apache httpclient; YouTubeService needs to be updated to use the new'* — flagged the migration as in-progress. `YouTubeService` has since been updated:

```
src/main/java/org/jasig/portlet/widget/service/YouTubeService.java:27:
    import org.apache.http.impl.client.HttpClients;
```

`grep -rl 'org.apache.commons.httpclient' src` returns nothing across the entire codebase. The legacy commons-httpclient pin is dead weight.

## Changes

`pom.xml`: remove the `commons-httpclient` block from both `<dependencyManagement>` (with its now-obsolete explanatory comment) and `<dependencies>`. Net 30 lines removed.

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green
- [ ] CI on Java 11 matrix