### PR TITLE
fix: complete commons-lang -> commons-lang3 migration after parent v51

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -18,56 +18,65 @@ under the License.
 This project includes:
   AJAX Portlet Support under The BSD License
   AOP alliance under Public Domain
-  Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons IO under Apache License, Version 2.0
+  Apache Commons Codec under Apache License, Version 2.0
+  Apache Commons Compress under Apache-2.0
+  Apache Commons IO under Apache-2.0
+  Apache Commons Lang under Apache-2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
   Apache Pluto Portlet Tag Library under The Apache Software License, Version 2.0
   Byte Buddy (without dependencies) under Apache License, Version 2.0
   Byte Buddy agent under Apache License, Version 2.0
+  CDI APIs under Apache License, Version 2.0
   Checker Qual under The MIT License
-  Codec under Apache License, Version 2.0
   Commons Lang under The Apache Software License, Version 2.0
   commons-beanutils under Apache License, Version 2.0
-  dom4j under BSD 3-clause New License
+  dom4j under Plexus
   ehcache under The Apache Software License, Version 2.0
   Ehcache Core under The Apache Software License, Version 2.0
   Ehcache Spring Annotations - Core under Apache 2
   Ehcache Web Filters under The Apache Software License, Version 2.0
   error-prone annotations under Apache 2.0
+  Esbuild wrapper for Java bundled with original binaries under MIT License
+  Expression Language 3.0 API under CDDL + GPLv2 with classpath exception
   ezmorph under The Apache Software License, Version 2.0
   FindBugs-jsr305 under The Apache Software License, Version 2.0
-  Groovy under The Apache Software License, Version 2.0
   Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
   Guava ListenableFuture only under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under Apache License, Version 2.0
   Hamcrest Core under New BSD License
   HttpClient under Apache License
   HyperSQL Database under HSQLDB License, a BSD open source license
-  J2ObjC Annotations under The Apache Software License, Version 2.0
+  istack common utility code runtime under Eclipse Distribution License - v 1.0
+  J2ObjC Annotations under Apache License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
   jackson-databind under The Apache Software License, Version 2.0
   Jakarta Activation under EDL 1.0
+  Jakarta Activation API jar under EDL 1.0
   Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   Jasig Widget Portlets under JA-SIG Collaborative Licence
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
-  Java Portlet Specification V2.0 under Commons Development and Distribution License, Version 1.0
+  Java Portlet API V3.0 under Apache License, Version 2.0
+  Java Servlet API under CDDL + GPLv2 with classpath exception
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
   javax.annotation API under CDDL + GPLv2 with classpath exception
+  javax.inject under The Apache Software License, Version 2.0
+  javax.interceptor API under CDDL + GPLv2 with classpath exception
+  JAXB Runtime under Eclipse Distribution License - v 1.0
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  jaxen under BSD License 2.0
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
+  jaxen under BSD 3-Clause License
+  JCL 1.2 implemented over SLF4J under Apache-2.0
   jdom under Apache style license
   json-lib under The Apache Software License, Version 2.0
   Json-lib4Spring under The Apache Software License, Version 2.0
   jstl under Commons Development and Distribution License, Version 1.0
-  JUL to SLF4J bridge under MIT License
+  JUL to SLF4J bridge under MIT
   JUnit under Eclipse Public License 1.0
-  Log4j Implemented Over SLF4J under Apache Software Licenses
-  Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
-  Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
+  Log4j Implemented Over SLF4J under Apache-2.0
+  Logback Classic Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
+  Logback Core Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
   mockito-core under The MIT License
   Objenesis under Apache License, Version 2.0
   Old JAXB Runtime under Eclipse Distribution License - v 1.0
@@ -78,8 +87,7 @@ This project includes:
   Resource Server Core under Apache License Version 2.0
   Resource Server Utilities under Apache License Version 2.0
   ROME, RSS and atOM utilitiEs for Java under Apache License, Version 2.0
-  servlet-api under Commons Development and Distribution License, Version 1.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
   Spring AOP under Apache License, Version 2.0
   Spring Beans under Apache License, Version 2.0
   Spring Context under Apache License, Version 2.0
@@ -95,5 +103,6 @@ This project includes:
   standard under Apache License, Version 2.0
   tomcat-jdbc under Apache License, Version 2.0
   tomcat-juli under Apache License, Version 2.0
+  TXW2 Runtime under Eclipse Distribution License - v 1.0
   uPortal under The Apache License, Version 2.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -139,11 +139,6 @@
                 <version>2.22.0</version>
             </dependency>
             <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.6</version>
-            </dependency>
-            <dependency>
                 <groupId>org.dom4j</groupId>
                 <artifactId>dom4j</artifactId>
                 <version>2.1.4</version>
@@ -465,8 +460,8 @@
             <version>2.22.0</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>org.dom4j</groupId>

--- a/src/main/java/org/jasig/portlet/widget/links/ResourceLinkService.java
+++ b/src/main/java/org/jasig/portlet/widget/links/ResourceLinkService.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
 public class ResourceLinkService {

--- a/src/main/java/org/jasig/portlet/widget/links/ResourceLinksConfigController.java
+++ b/src/main/java/org/jasig/portlet/widget/links/ResourceLinksConfigController.java
@@ -29,7 +29,7 @@ import javax.portlet.PortletMode;
 import javax.portlet.PortletRequest;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/org/jasig/portlet/widget/mvc/PluggableDataJspPortletController.java
+++ b/src/main/java/org/jasig/portlet/widget/mvc/PluggableDataJspPortletController.java
@@ -32,7 +32,7 @@ import javax.portlet.ResourceResponse;
 
 import net.sf.json.JSON;
 import net.sf.json.JSONSerializer;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jasig.portlet.widget.dao.PluggableDataDao;

--- a/src/main/java/org/jasig/portlet/widget/mvc/SimpleJspPortletController.java
+++ b/src/main/java/org/jasig/portlet/widget/mvc/SimpleJspPortletController.java
@@ -31,7 +31,7 @@ import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 import javax.portlet.RenderRequest;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/org/jasig/portlet/widget/mvc/app/AppDefinition.java
+++ b/src/main/java/org/jasig/portlet/widget/mvc/app/AppDefinition.java
@@ -29,7 +29,7 @@ import javax.portlet.ActionRequest;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class AppDefinition implements Serializable {
 

--- a/src/main/java/org/jasig/portlet/widget/mvc/app/AppLauncherConfigController.java
+++ b/src/main/java/org/jasig/portlet/widget/mvc/app/AppLauncherConfigController.java
@@ -30,7 +30,7 @@ import javax.portlet.PortletModeException;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletSession;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/org/jasig/portlet/widget/service/GoogleGadgetService.java
+++ b/src/main/java/org/jasig/portlet/widget/service/GoogleGadgetService.java
@@ -33,7 +33,7 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpEntity;


### PR DESCRIPTION
**Master is currently in a half-broken state:** PR #313 bumped \`uportal-portlet-parent\` to v51 (which dropped \`commons-lang\` from \`dependencyManagement\`), but the source code still imports from \`org.apache.commons.lang.*\` and the local pom still carries a versionless \`commons-lang\` dM entry plus a versionless \`commons-lang\` dependency. The build passes only because Maven is resolving \`commons-lang\` from somewhere (likely the local m2 cache from prior builds). This PR completes the migration.

## Summary

Two commits:

1. **commons-lang -> commons-lang3 migration** — drop the local versionless \`commons-lang\` dM entry in \`pom.xml\`, swap the \`commons-lang:commons-lang\` \`<dependency>\` for \`org.apache.commons:commons-lang3\` (parent v51 manages the version at 3.20.0), and rename \`org.apache.commons.lang.*\` -> \`org.apache.commons.lang3.*\` across the 7 source files using \`StringUtils\`. lang3 is API-compatible for \`StringUtils\`. Closes CVE-2025-48924.
2. **Regenerate NOTICE** — aligns with the post-v51 dep tree (Apache-2.0 normalization on Commons Codec / Lang / IO, Logback EPL v1 -> v2).

The earlier dead-pin cleanup (#310 \`commons-httpclient\`) and the parent v51 bump (#313) shipped separately.

## Test plan

- [x] \`mvn -B clean install\` passes locally on Java 11
- [x] \`mvn notice:check\` passes
- [x] \`mvn license:check\` passes
- [ ] CI green
- [ ] Post-merge: \`mvn release:clean release:prepare release:perform\` for jasig-widget-portlets-2.4.1