### PR TITLE
fix: re-add commons-collections runtime dep for json-lib ListOrderedMap

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -19,6 +19,7 @@ This project includes:
   AJAX Portlet Support under The BSD License
   AOP alliance under Public Domain
   Apache Commons Codec under Apache License, Version 2.0
+  Apache Commons Collections under Apache License, Version 2.0
   Apache Commons Compress under Apache-2.0
   Apache Commons IO under Apache-2.0
   Apache Commons Lang under Apache-2.0

--- a/pom.xml
+++ b/pom.xml
@@ -185,10 +185,6 @@
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <groupId>commons-collections</groupId>
-                        <artifactId>commons-collections</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -507,16 +503,27 @@
                     <groupId>javax.servlet</groupId>
                     <artifactId>servlet-api</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>commons-collections</groupId>
-                    <artifactId>commons-collections</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
+
+        <!-- json-lib's JSONObject (used by net.sf.json.spring.web.servlet.view.JsonView)
+             needs org.apache.commons.collections.map.ListOrderedMap at runtime.
+             uportal-portlet-parent v51 banned commons-collections [3.2.1,4.0]
+             over CVE-2015-6420; the enforcer override below allows 3.2.2
+             specifically. The CVE is a deserialization RCE that requires
+             attacker-controlled serialized input, which json-lib's internal
+             ListOrderedMap usage doesn't expose. Pinned in dependencyManagement
+             above; declared explicitly here so the WAR bundles it. -->
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
@@ -799,6 +806,33 @@
 
     <build>
             <plugins>
+
+                <!-- Local enforcer override: parent v51 bans
+                     commons-collections [3.2.1,4.0] over CVE-2015-6420, but
+                     json-lib needs ListOrderedMap from 3.2.2 at runtime
+                     (see the commons-collections dependency block above for
+                     full context). Allow 3.2.2 specifically here. Drop once
+                     json-lib is replaced (e.g. with Jackson's ObjectMapper).
+                  -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>enforce-versions</id>
+                            <configuration>
+                                <rules>
+                                    <bannedDependencies>
+                                        <includes>
+                                            <include>commons-collections:commons-collections:3.2.2</include>
+                                        </includes>
+                                    </bannedDependencies>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>


### PR DESCRIPTION
## Problem

2.4.1 dropped \`commons-collections\` from the runtime classpath by excluding it from \`json-lib-ext-spring\`'s transitive deps (both in the local \`dependencyManagement\` and in the actual \`<dependency>\` block). The exclusion citations referenced CVE-2015-6420 and the \`uportal-portlet-parent\` v51 banned-deps enforcer rule.

\`json-lib\`'s \`net.sf.json.JSONObject\` (used by \`net.sf.json.spring.web.servlet.view.JsonView\`, which is the configured view in \`/WEB-INF/context/views.xml\`) initializes \`CycleDetectionStrategy\` at static init, which constructs an \`org.apache.commons.collections.map.ListOrderedMap\`. Without \`commons-collections\` on the runtime classpath the Spring root context fails to start with \`NoClassDefFoundError\`, taking the entire webapp down. The bare \`mvn package\` CI never exercised the failing path so the regression shipped silently in 2.4.1.

## CVE risk assessment

CVE-2015-6420 against \`commons-collections\` 3.2.2 is a deserialization RCE that requires attacker-controlled serialized input. \`json-lib\`'s internal \`ListOrderedMap\` usage doesn't expose that surface; the dep is on the runtime classpath but isn't reachable from any remote-attacker-controlled deserialization path here. Per-portlet override (rather than fleet-wide unbanning) is the right scope until \`json-lib\` is replaced — e.g. with Jackson's \`ObjectMapper\`, which is a separate refactor tracked at the fleet level.

## Changes

- **pom.xml**:
  - Drop the now-counterproductive \`<exclusion>commons-collections</>\` blocks under \`json-lib-ext-spring\` (both in \`dependencyManagement\` and the actual dependency declaration).
  - Add an explicit \`<dependency>commons-collections:commons-collections</>\` at \`runtime\` scope (version inherited from this portlet's \`dependencyManagement\` which already pinned 3.2.2).
  - Add a local \`maven-enforcer-plugin\` override re-allowing 3.2.2 specifically via \`bannedDependencies/<includes>\`. The parent's broader \`[3.2.1,4.0]\` ban stays intact for everything else.
- **NOTICE**: regenerated to include "Apache Commons Collections".

## Test plan

- [x] \`mvn -B clean install notice:check license:check\` passes locally on Java 11
- [x] Built locally as \`2.4.2-SNAPSHOT\`, deployed into uPortal-start, restarted Tomcat — \`commons-collections-3.2.2.jar\` is bundled in the WAR; no \`ListOrderedMap\` / \`Context [/jasig-widget-portlets] startup failed\` errors in the logs
- [ ] CI green
- [ ] Post-merge: \`mvn release:clean release:prepare release:perform\` for 2.4.2