### PR TITLE
chore(deps): block renovate noise on jakarta-migration + retired-project deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,7 @@
     {
       "matchPackageNames": [
         "com.sun.xml.bind:jaxb-impl",
+        "com.sun.xml.bind:jaxb-xjc",
         "jakarta.xml.bind:jakarta.xml.bind-api",
         "org.glassfish.jaxb:jaxb-runtime"
       ],
@@ -48,6 +49,27 @@
       "matchPackageNames": ["javax.servlet:javax.servlet-api"],
       "allowedVersions": "< 5.0",
       "description": "Servlet API 5+ is in the Jakarta EE namespace and incompatible with this portlet's javax.servlet imports. Runtime is Tomcat 8.5/9 (Servlet 3.1)."
+    },
+    {
+      "matchPackagePrefixes": ["org.apache.portals.pluto:"],
+      "allowedVersions": "< 3.0",
+      "description": "Apache Pluto is in the Attic; pluto-taglib 3.x and the rest of Pluto 3.x ship in the jakarta.portlet namespace, which uPortal cannot move to since the embedded Pluto container has no jakarta path. Stay on 2.1.0-M3 (the last javax.portlet release)."
+    },
+    {
+      "matchPackageNames": ["jaxen:jaxen"],
+      "allowedVersions": "< 2.0",
+      "description": "This portlet pins jaxen to Atlassian's 1.2.0-atlassian-2 fork (same pattern used for commons-lang and ehcache-spring-annotations). Jaxen 2.x is the mainline release and would back out of the fork-tracking convention; ignore until the fork policy is revisited."
+    },
+    {
+      "matchPackagePrefixes": ["org.junit.jupiter:", "org.junit.platform:"],
+      "matchPackageNames": ["org.junit:junit-bom"],
+      "enabled": false,
+      "description": "Tests are JUnit 4 (4.13.2 via uportal-portlet-parent) + Mockito. JUnit 5 (Jupiter) is a separate test engine; migrating would require re-annotating every @Before/@Test/@RunWith and is out of scope for the current parent."
+    },
+    {
+      "matchPackagePrefixes": ["com.liferay.portletmvc4spring:"],
+      "allowedVersions": "< 6.0",
+      "description": "Currently on portletmvc4spring 5.2.0 (Spring 4.3.x line). The 6.0.0-M1 milestone exists in Liferay's git but has not been published to Maven Central, and the upgrade requires Spring 6 + Jakarta EE + Java 17 — three migrations this portlet is not doing yet."
     }
   ]
 }


### PR DESCRIPTION
## Summary

5 renovate PRs are open right now against deps this portlet can't take, and a couple more dep families are coming via renovate eventually that are equally out-of-scope. This PR encodes the existing review decisions as `packageRules` so they stop showing up.

**New rules:**

1. **`org.apache.portals.pluto:*` `< 3.0`** — Apache Pluto is in the Attic; v3.x is `jakarta.portlet`. uPortal's embedded Pluto has no jakarta path. Closes #312 once renovate re-evaluates.
2. **`jaxen:jaxen` `< 2.0`** — Stay on Atlassian's `1.2.0-atlassian-2` fork (matches the convention with commons-lang, ehcache-spring-annotations). Closes #311.
3. **`org.junit.jupiter:*` / `org.junit.platform:*` / `org.junit:junit-bom` `enabled: false`** — Project is JUnit 4.13.2 via parent; CLAUDE.md / project policy says no Jupiter migration scoped.
4. **`com.liferay.portletmvc4spring:*` `< 6.0`** — 6.0.0-M1 isn't on Maven Central + the upgrade is a three-stack migration (Spring 6 + Jakarta + Java 17).
5. **Extend existing JAXB rule to include `com.sun.xml.bind:jaxb-xjc`** — same `jakarta.xml.bind` namespace shift at v4. Closes #309.

**Skipped**: Hibernate (not a direct or surfaced transitive in this pom).

## Test plan

- [ ] `python3 -c 'import json; json.load(open("renovate.json"))'` — JSON syntax valid (verified locally)
- [ ] After merge: confirm renovate auto-closes #309, #311, #312 within its next run
- [ ] Forward-looking: when renovate next evaluates JUnit 5 / portletmvc4spring 6 candidates, they don't open as PRs