### PR TITLE
docs: mark repo deprecated; point at uPortal-start retirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+## DEPRECATED -- no longer maintained
+
+This repository is deprecated and will not receive further updates. Of the eleven widgets it bundles, seven depend on Google APIs that were sunset years ago (Google Loader 2015, Maps v3.6, Google Gadgets ~2016); the remaining widgets are JSP demos, trivial date/dictionary/embed shapes, or have been absorbed into uPortal core (`AppLauncherPortlet`).
+
+uPortal-start no longer ships `JasigWidgetPortlets` in the default overlay set (see [uPortal-Project/uPortal-start#696](https://github.com/uPortal-Project/uPortal-start/pull/696)).
+
+**Recommended action for deployers:** remove this overlay from your deployment and drop any quickstart portlet definitions that bind to `/jasig-widget-portlets`. If you still actively use the dictionary, calendar, or youtube widget shapes, open an issue -- they can be ported to a small Lit web component on request.
+
+The repository will remain on GitHub for historical reference but receives no further releases.
+
+---
+
 # Jasig Widget Portlets
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jasig.portlet/jasig-widget-portlets/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jasig.portlet/jasig-widget-portlets)


### PR DESCRIPTION
## Summary

Add a deprecation banner to the top of `README.md` to signal that this repo is no longer maintained and to point at [uPortal-Project/uPortal-start#696](https://github.com/uPortal-Project/uPortal-start/pull/696), which drops the overlay from uPortal-start's default set.

## Why

Of the 11 widgets this repo ships:

- 7 depend on Google APIs that have been gone for nearly a decade (Google Loader 2015, Maps v3.6 EOL, Google Gadgets discontinued ~2016).
- 3 are JSP demos / instructional examples (`SimpleJspPortlet`, `PluggableDataJspPortlet`, `tips`) that were never intended as load-bearing widgets.
- The remaining trivial widgets (dictionary, calendar, youtube embed) are tiny enough to port to a Lit web component on request.

`AppLauncherPortlet` already lives in uPortal core; this repo is no longer its canonical home.

The repo continues to draw renovate-driven dependency-bump churn for code that nobody can run usefully. The README banner makes the deprecation visible to anyone arriving at the repo.

## Changes

- `README.md`: insert a deprecation block at the top with rationale, recommended deployer action (remove overlay, drop quickstart definitions binding to `/jasig-widget-portlets`), and a link to the uPortal-start retirement PR. Original README content preserved below a divider.

## Test plan

- [ ] README renders correctly on GitHub with the banner visible above the original content.
- [ ] No code or configuration changes — pure documentation.

## Follow-ups

- Once both PRs land, the GitHub repo can be flagged as archived (UI action, not a PR) at the maintainer's discretion.
- A subscriber announcement covering the retirement is queued for the bi-weekly comms workstream.